### PR TITLE
Pull multiple series over arbitrary periods

### DIFF
--- a/bls/api.py
+++ b/bls/api.py
@@ -48,13 +48,13 @@ def _get_json(series, startyear=None, endyear=None, key=None,
         startyear = int(endyear) - 10
 
     # TODO: daisy-chain requests to cover full timespan
-    key = key if key else _KEY.key
+    key = key or _KEY.key
     data = {
         "seriesid": series,
         "startyear": startyear,
         "endyear": endyear
     }
-    if key is not None:
+    if key:
         data.update({
             'registrationkey': key,
             'catalog': catalog,

--- a/bls/api.py
+++ b/bls/api.py
@@ -34,18 +34,21 @@ def unset_api_key():
 
 def _get_json(series, startyear=None, endyear=None, key=None,
               catalog=False, calculations=False, annualaverages=False):
+
+    # Process keywords and set defaults
     if type(series) == str:
         series = [series]
     thisyear = datetime.datetime.today().year
-    if endyear is None or int(endyear) > thisyear:
-        if startyear is None:
+    if not (endyear and int(endyear) <= thisyear):
+        if not startyear:
             endyear, startyear = thisyear, thisyear - 9
         else:
             endyear = min(int(startyear) + 9, thisyear)
-    elif startyear is None:
+    elif not startyear:
         startyear = int(endyear) - 10
+
     # TODO: daisy-chain requests to cover full timespan
-    key = key if key is not None else _KEY.key
+    key = key if key else _KEY.key
     data = {
         "seriesid": series,
         "startyear": startyear,

--- a/bls/api.py
+++ b/bls/api.py
@@ -14,7 +14,7 @@ import pandas as pd
 
 BASE_URL = "https://api.bls.gov/publicAPI/v2/timeseries/data/"
 
-_concat = lambda iterable: sum(iterable, [])
+listsum = lambda iterable: sum(iterable, [])
 
 
 class _Key(object):
@@ -74,7 +74,7 @@ def _get_json(series, startyear=None, endyear=None, key=None,
 
     merged = { 
             'series': [ { 
-                'data': _concat([r['series'][0]['data'] for r in results]),
+                'data': listsum([r['series'][0]['data'] for r in results]),
                 'seriesID': results[0]['series'][0]['seriesID']
                 }] 
             }

--- a/bls/api.py
+++ b/bls/api.py
@@ -74,11 +74,15 @@ def _get_json(series, startyear=None, endyear=None, key=None,
             headers=_headers).json()["Results"])
         startyear, sectionyear = sectionyear + 1, min(sectionyear + 10, endyear)
 
+    num_decades = len(results)
+    num_series = len(results[0]['series'])
+
     merged = { 
             'series': [{ 
-                'data': listsum([results[j]['series'][0]['data'] for j in range(len(results))]),
-                'seriesID': results[0]['series'][i]['seriesID'],
-                } for i in range(len(results[0]['series']))]
+                'data': listsum([results[j]['series'][0]['data'] \
+                        for j in range(num_decades)]),
+                'seriesID': results[0]['series'][i]['seriesID'], 
+                } for i in range(num_series)]
             }
 
     return merged 


### PR DESCRIPTION
This update would allow the API to specify arbitrary period lengths for BLS queries and for multiple series. For example, the call
```Python
get_series(['CUUR0000SA0','SUUR0000SA0'], startyear=2000, endyear=2015)
```
will return a pandas DataFrame containing the columns "CUUR0000SA0" and "SUUR0000SA0" with a date index from 2000-01-01 to 2015-12-01.