### PR TITLE
Not all indexes returned can use to_datetime

### DIFF
--- a/bls/api.py
+++ b/bls/api.py
@@ -85,6 +85,6 @@ def get_series(series, startyear=None, endyear=None, key=None,
             for i in series["data"]
             if i["period"] != "M13"
         } for series in results["series"]})
-    df.index = pd.to_datetime(df.index)
+    df.index = pd.to_datetime(df.index, errors='ignore')
     df = df.applymap(float)
     return df[df.columns[0]] if len(df.columns) == 1 else df


### PR DESCRIPTION

Example:

data = bls.get_series('CIU2020000000000A',startyear='2015',endyear='2016',key=apikey)

Manipulation of the index should probably be handled altogether elsewhere, this is a seamless quick fix.