### PR TITLE
Added option to allow calculations on series. 

### DIFF
--- a/bls/api.py
+++ b/bls/api.py
@@ -8,6 +8,7 @@ from __future__ import (print_function, division, absolute_import,
 import collections
 import datetime
 import logging
+import warnings
 
 
 import os
@@ -87,11 +88,6 @@ def get_json_series(series, startyear=None, endyear=None, key=None):
 
 
 def parse_series(series):
-    if not len(series['data']):
-        raise ValueError(
-            'No data received for series {}! Are your parameters correct?'
-            .format(series['seriesID'])
-        )
     df = pd.DataFrame(series['data'])
     freq = df['period'].iloc[0][0]
     if freq == 'A':
@@ -125,7 +121,7 @@ def parse_series(series):
     raise ValueError('Unknown period format: {}'.format(df['period'].iloc[0]))
 
 
-def get_series(series, startyear=None, endyear=None, key=None):
+def get_series(series, startyear=None, endyear=None, key=None, errors='raise'):
     """
     Retrieve one or more series from BLS. Note that only ten years may be
     retrieved at a time
@@ -135,14 +131,28 @@ def get_series(series, startyear=None, endyear=None, key=None):
         years before the endyear
     :endyear: The last year for which to retrieve data. Defaults to ten years
         after the startyear, if given, or else the current year
+    :errors: {'ignore', 'raise'}, default 'raise'
+        If 'ignore', suppress error and only existing series are returned.
     :returns: a pandas DataFrame object with each series as a column and each
         monthly observation as a row. If only one series is requested, a pandas
         Series object is returned instead of a DataFrame.
     """
     results = get_json_series(series, startyear, endyear, key)
+    # Parse out invalid seriesID(s)
+    invalid_ids = [res['seriesID'] for res in results if not res['data']]
+    if errors == 'raise' and invalid_ids:
+        raise ValueError(
+            'No data received for series {}! Are your parameters correct?'
+            .format(invalid_ids)
+        )
+    if invalid_ids:
+        warnings.warn(
+            'No data received for series {}! Are your parameters correct?'
+            .format(invalid_ids)
+        )
     df = pd.DataFrame({
         result["seriesID"]: parse_series(result)
-        for result in results
+        for result in results if result['seriesID'] not in invalid_ids
     })
     df = df.applymap(float)
-    return df[series].sort_index()
+    return df[df.columns].sort_index()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,7 +16,7 @@ def nokey():
 def test_monthly_value():
     assert bls.get_series(
         'LNS14000000', startyear=1948, endyear=1948
-    )['1948-01'] == 3.4
+    )['1948-01'].iloc[0][0] == 3.4
 
 
 def test_monthly_value_multiple():
@@ -37,13 +37,13 @@ def test_monthly_value_multiple():
 def test_quarterly_value():
     assert bls.get_series(
         'CIU2020000000000A', startyear=2001, endyear=2001
-    )['2001-Q1'] == 3.8
+    )['2001-Q1'].iloc[0][0] == 3.8
 
 
 def test_annual_value():
     assert bls.get_series(
         'TUU10100AA01000007', startyear=2009, endyear=2009
-    )['2009'] == 148720
+    )['2009'].iloc[0][0] == 148720
 
 
 def test_key_till_thisyear():
@@ -78,4 +78,11 @@ def test_error_no_key_too_many_years(nokey):
 
 def test_error_no_data():
     with pytest.raises(ValueError):
-        bls.get_series('LNS14000000', startyear=1900, endyear=1900)
+        bls.get_series('LNS1400000', startyear=1900, endyear=1900)
+
+
+def test_warning_and_not_valuerror_when_errors_set_to_ignore():
+    with pytest.warns(UserWarning):
+        bls.get_series(
+            ['LNS14000000', 'INVALID_SERIESID'], endyear=2018, errors='ignore'
+        )


### PR DESCRIPTION
BLS Public Data API Signatures (Version 2.0) add the ability to query optional parameters.  Calculations is one of them. This new update now allows people to create a dictionary parameter in the `bls.api.get_series()` function. This of course will only work if users provide a key, but luckily the BLS server still provides values and simply omits the calculations if no key is provided. This makes crashing the program much less likely. I've also added some error messages to help users who do not provide correct values. 

Here is how it can be used to get net monthly changes for series id: CES000000000:

```
import bls
calcs = {
    'period' : 1,
    'calc_type': 'net_changes'
}

bls.get_series('CES0000000001', calculations=calcs)
```

Let me know what you think, as well as any improvements you think I can make here. 