### PR TITLE
Add ability to ignore invalid ids

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,12 @@ def nokey():
 
 
 def test_monthly_value():
-    assert bls.get_series("LNS14000000", startyear=1948, endyear=1948)["1948-01"] == 3.4
+    assert (
+        bls.get_series("LNS14000000", startyear=1948, endyear=1948)["1948-01"].iloc[0][
+            0
+        ]
+        == 3.4
+    )
 
 
 def test_monthly_value_multiple():
@@ -27,14 +32,18 @@ def test_monthly_value_multiple():
 
 def test_quarterly_value():
     assert (
-        bls.get_series("CIU2020000000000A", startyear=2001, endyear=2001)["2001-Q1"]
+        bls.get_series("CIU2020000000000A", startyear=2001, endyear=2001)[
+            "2001-Q1"
+        ].iloc[0][0]
         == 3.8
     )
 
 
 def test_annual_value():
     assert (
-        bls.get_series("TUU10100AA01000007", startyear=2009, endyear=2009)["2009"]
+        bls.get_series("TUU10100AA01000007", startyear=2009, endyear=2009)["2009"].iloc[
+            0
+        ][0]
         == 148720
     )
 
@@ -72,3 +81,10 @@ def test_error_no_key_too_many_years(nokey):
 def test_error_no_data():
     with pytest.raises(ValueError):
         bls.get_series("LNS14000000", startyear=1900, endyear=1900)
+
+
+def test_warning_and_not_valuerror_when_errors_set_to_ignore():
+    with pytest.warns(UserWarning):
+        bls.get_series(
+            ["LNS14000000", "INVALID_SERIESID"], endyear=2018, errors="ignore"
+        )


### PR DESCRIPTION
@OliverSherouse, I think it would be a vast improvement if we can add the option to ignore invalid ids. There are times where I have just one or two invalid series ids in the mix, but the rest are fine. I don't see why the whole get_series request should fail because of those couple wrong ids.

The new approach still let's the user know if there was a bad id (or ids), but it instead throws a warning message instead. This all requires using a new keyword argument though, called errors. I modeled this off of pandas.Dataframe.drop which also has the same type of argument.

Besides that change, I also had to adjust a few of the test cases since a dataframe is now being returned instead of a series. Reason is because I'm now using an array to create the final returned dataframe and that coerces the series into a dataframe. In the end, I actually think this is an improvement since the datatype doesn't change from the enduser perspective.